### PR TITLE
Updating maintainer field syntax

### DIFF
--- a/3d-dna/Dockerfile
+++ b/3d-dna/Dockerfile
@@ -5,12 +5,12 @@ LABEL software="3d-dna" \
     about.summary="" \ 
     about.home="https://github.com/aidenlab/3d-dna" \ 
     software.version="180922" \ 
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     upstream.version="180922" \ 
     version="1" \ 
     about.copyright="Dudchenko, O., Batra, S.S., Omer, A.D., Nyquist, S.K., Hoeger, M., Durand, N.C., Shamim, M.S., Machol, I., Lander, E.S., Aiden, A.P., et al." \ 
     about.license="MIT" \ 
-    dockerfile.author="Sebastian Bassi <sebastian@toyoko.io>" \
-     about.tags=""
+    about.tags=""
 
 USER root
 ENV DEBIAN_FRONTEND noninteractive

--- a/anvio/7.1/Dockerfile
+++ b/anvio/7.1/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bookworm-slim
 
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
-LABEL    software="Anvio"
+LABEL    software="Anvio" \
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>"
 
 ADD anvio71.yaml /tmp
 ADD requirements.txt /tmp

--- a/bedtools/2.31.1+dfsg-2-deb/Dockerfile
+++ b/bedtools/2.31.1+dfsg-2-deb/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:trixie-slim
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
+
 LABEL    software="bedtools" \ 
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     base_image="trixie:slim" \ 
     container="bedtools" \ 
     about.summary="suite of utilities for comparing genomic features" \ 

--- a/biocontainers/debian-buster-backports/Dockerfile
+++ b/biocontainers/debian-buster-backports/Dockerfile
@@ -4,14 +4,13 @@ LABEL base.image="debian:buster-backports"
 LABEL version=2
 LABEL software="Biocontainers debian based image"
 LABEL software.version="debian-buster-backports"
+LABEL maintainer="Mateo Boudet <mateo.boudet@irisa.fr>"
 LABEL about.summary="Base image for BioDocker"
 LABEL about.home="http://biocontainers.pro"
 LABEL about.documentation="https://github.com/BioContainers/specs/wiki"
 LABEL about.license_file="https://github.com/BioContainers/containers/blob/master/LICENSE"
 LABEL about.license="SPDX:Apache-2.0"
 LABEL about.tags="Genomics,Proteomics,Transcriptomics,General,Metabolomics"
-
-MAINTAINER Mateo Boudet <mateo.boudet@irisa.fr>
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN mkdir /data /config

--- a/biopython/1.84-pip/Dockerfile
+++ b/biopython/1.84-pip/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:trixie-slim
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
+
 LABEL    software="biopython" \ 
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     base_image="biocontainers/biocontainers:vdebian-buster-backports_cv1" \ 
     container="biopython" \ 
     about.summary="Python library for bioinformatics (implemented in Python 3)" \ 

--- a/blast2/2.16.0-mix/Dockerfile
+++ b/blast2/2.16.0-mix/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 ARG version=2.16.0
 
-LABEL maintainer="sebastian@toyoko.io"
+LABEL maintainer="Sebastian Bassi <sebastian@toyoko.io>"
 
 USER root
 

--- a/blaze/2.2.0/Dockerfile
+++ b/blaze/2.2.0/Dockerfile
@@ -6,14 +6,12 @@ LABEL base_image="python:3.10.1"
 LABEL version="1"
 LABEL software="BLAZE"
 LABEL software.version="2.2.0"
+LABEL maintainer="Austyn Trull <atrull@uab.edu>" 
 LABEL about.summary="Barcode identification from Long reads for AnalyZing single cell gene Expression."
 LABEL about.home="https://github.com/shimlab/BLAZE/"
 LABEL about.license="GPL-3.0-only"
 LABEL about.license_file="https://github.com/shimlab/BLAZE/blob/main/LICENSE"
 LABEL extra.identifiers.biotools="blaze"
-
-################## MAINTAINER ######################
-MAINTAINER "Austyn Trull <atrull@uab.edu>"
 
 ################## INSTALLATION ######################
 

--- a/bowtie2/2.5.4/Dockerfile
+++ b/bowtie2/2.5.4/Dockerfile
@@ -1,6 +1,7 @@
 FROM continuumio/miniconda3
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
-LABEL    software="bowtie2"
+
+LABEL    software="bowtie2" \
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>"
 
 ARG software_version=2.5.4
 

--- a/bwa/0.7.17-7-deb/Dockerfile
+++ b/bwa/0.7.17-7-deb/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:trixie-slim
 
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
 LABEL    software="bwa" \ 
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     base_image="debian:trixie-slim" \ 
     container="bwa" \ 
     about.summary="Burrows-Wheeler Aligner" \ 

--- a/bwa/0.7.18-1-deb/Dockerfile
+++ b/bwa/0.7.18-1-deb/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:trixie-slim
 
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
 LABEL    software="bwa" \ 
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     base_image="debian:trixie-slim" \ 
     container="bwa" \ 
     about.summary="Burrows-Wheeler Aligner" \ 

--- a/cadd-scripts-with-envs/1.6.post1/Dockerfile
+++ b/cadd-scripts-with-envs/1.6.post1/Dockerfile
@@ -3,9 +3,9 @@ FROM mambaorg/micromamba:1.5.3
 ARG CADD_VERSION=1.6.post1
 ARG CADD_CONFIG_VERSION=1.6
 
-MAINTAINER "Marius Bjoernstad" <pmb@fa2k.net>
 LABEL software="cadd-scripts-with-envs" \
     software.version="$CADD_VERSION" \
+    maintainer="Marius Bjoernstad <pmb@fa2k.net>" \
     version="1" \
     about.summary="CADD is a tool for scoring the deleteriousness of single nucleotide variants as well as insertion/deletions variants in the human genome" \
     about.home="https://cadd.gs.washington.edu/" \

--- a/cadd-scripts-with-envs/1.6/Dockerfile
+++ b/cadd-scripts-with-envs/1.6/Dockerfile
@@ -2,9 +2,9 @@ FROM mambaorg/micromamba:1.5.3
 
 ARG CADD_VERSION=1.6
 
-MAINTAINER "Marius Bjoernstad" <pmb@fa2k.net>
 LABEL software="cadd-scripts-with-envs" \
     software.version="${CADD_VERSION}" \
+    maintainer="Marius Bjoernstad <pmb@fa2k.net>" \
     version="1" \
     about.summary="CADD is a tool for scoring the deleteriousness of single nucleotide variants as well as insertion/deletions variants in the human genome" \
     about.home="https://cadd.gs.washington.edu/" \

--- a/cellpose/3.0.1/Dockerfile
+++ b/cellpose/3.0.1/Dockerfile
@@ -4,15 +4,13 @@ LABEL base_image="python:3.11"
 LABEL version="1"
 LABEL software="cellpose"
 LABEL software.version="3.0.1"
+LABEL maintainer="Yi Sun <sunyi000@gmail.com>, Florian Wuennemann <flowuenne@gmail.com>"
 LABEL about.summary="A generalist algorithm for cell and nucleus segmentation."
 LABEL about.home="https://github.com/MouseLand/cellpose"
 LABEL about.license="BSD-3-Clause"
 LABEL about.license_file="https://github.com/MouseLand/cellpose/blob/main/LICENSE"
 LABEL about.documentation="https://cellpose.readthedocs.io/en/latest/"
 LABEL extra.identifiers.biotools=cellpose
-
-MAINTAINER Yi Sun <sunyi000@gmail.com>
-MAINTAINER Florian Wuennemann <flowuenne@gmail.com>
 
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG CELLPOSE_VERSION="3.0.1"

--- a/clustalo/1.2.4-conda/Dockerfile
+++ b/clustalo/1.2.4-conda/Dockerfile
@@ -8,13 +8,11 @@ LABEL version="1"
 LABEL about.summary="making accurate alignments of many protein sequences"
 LABEL software="Clustal Omega"
 LABEL software.version="1.2.4"
+LABEL maintainer="Sebastian Bassi <sebastian@toyoko.io>"
 LABEL about.tags="Genomics"
 LABEL about.home="http://www.clustal.org/omega/"
 LABEL about.license="GPL-3.0"
 LABEL about.author="Sievers F, Wilm A, Dineen DG, Gibson TJ, Karplus K, Li W, Lopez R, McWilliam H, Remmert M, Söding J, Thompson JD, Higgins DG "
-
-################## MAINTAINER ######################
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
 
 RUN conda install -c conda-forge -c bioconda clustalo==1.2.4
 

--- a/clustalo/1.2.4-deb/Dockerfile
+++ b/clustalo/1.2.4-deb/Dockerfile
@@ -1,10 +1,10 @@
 FROM debian:trixie-slim
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
 
 LABEL version="1.2.4"
 LABEL about.summary="Making accurate alignments of many protein sequences"
 LABEL software="Clustal Omega"
 LABEL software.version="1.2.4"
+LABEL maintainer="Sebastian Bassi <sebastian@toyoko.io>"
 LABEL about.tags="Genomics"
 LABEL about.home="http://www.clustal.org/omega/"
 LABEL about.license="GPL-3.0"

--- a/cvtree/3.0.0/Dockerfile
+++ b/cvtree/3.0.0/Dockerfile
@@ -1,7 +1,7 @@
 ## Stage for build cvtree
 FROM alpine AS dev
 LABEL Version=0.2 \
-  MAINTAINER="Sebastian Bassi <sebastian@toyoko.io>"\
+  maintainer="Sebastian Bassi <sebastian@toyoko.io>"\
   description="Docker image for CVTree" 
 
 # Original author: Dr. Guanghong Zuo

--- a/dask/2023.10.1-py11-ol9/Dockerfile
+++ b/dask/2023.10.1-py11-ol9/Dockerfile
@@ -2,12 +2,11 @@ ARG DASK_VERSION=2023.10.1
 
 FROM oraclelinux:9
 
-MAINTAINER biocontainers <biodocker@gmail.com>
-
 LABEL base_image="oraclelinux:9"
 LABEL version="1"
 LABEL software="Dask"
 LABEL software.version="2023.10.1-py11-ol9"
+LABEL maintainer="Biocontainers <biodocker@gmail.com>"
 LABEL about.summary="Dask is a flexible library for parallel computing in Python."
 LABEL about.home="https://www.dask.org"
 LABEL about.license="BSD-3-Clause"

--- a/diann/1.8.1/Dockerfile
+++ b/diann/1.8.1/Dockerfile
@@ -6,15 +6,13 @@ LABEL base_image="ubuntu:latest"
 LABEL version="2"
 LABEL software="diann"
 LABEL software.version="1.8.1"
+LABEL maintainer="Yasset Perez-Riverol <ypriverol@gmail.com>"
 LABEL about.summary="DIA-NN - a universal software for data-independent acquisition (DIA) proteomics data processing."
 LABEL about.home="https://github.com/vdemichev/DiaNN"
 LABEL about.documentation="https://github.com/vdemichev/DiaNN"
 LABEL about.license_file="https://github.com/vdemichev/DiaNN/LICENSE.txt"
 LABEL about.license="SPDX:CC-BY-NC-4.0"
 LABEL about.tags="Proteomics"
-
-################## MAINTAINER ######################
-MAINTAINER Yasset Perez-Riverol <ypriverol@gmail.com>
 
 ################## INSTALLATION ######################
 

--- a/evidential-gene/23jul15/Dockerfile
+++ b/evidential-gene/23jul15/Dockerfile
@@ -6,14 +6,12 @@ LABEL base_image="biocontainers:v1.2.0_cv2"
 LABEL version="1"
 LABEL software="evidential-gene"
 LABEL software.version="23jul15"
+LABEL maintainer="Avani Bhojwani <avani.bhojwani@gmail.com>"
 LABEL about.summary="EvidentialGene is a genome informatics project for Evidence Directed Gene Construction for Eukaryotes"
 LABEL about.home="http://arthropods.eugenes.org/EvidentialGene/evigene/"
 LABEL about.documentation="http://arthropods.eugenes.org/EvidentialGene/evigene/docs/"
 LABEL about.license_file="http://arthropods.eugenes.org/about/about-EvidentialGene/"
 LABEL about.tags="Genomics, Transcriptomics"
-
-################## MAINTAINER ######################
-MAINTAINER Avani Bhojwani <avani.bhojwani@gmail.com>
 
 ################## INSTALLATION ######################
 

--- a/fastp/0.23.4-conda/Dockerfile
+++ b/fastp/0.23.4-conda/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bookworm-slim
 
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
-LABEL    software="fastp"
+LABEL    software="fastp" \
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>"
 
 ARG software_version=0.23.4
 

--- a/fastqc/0.12.1+dfsg-3-deb/Dockerfile
+++ b/fastqc/0.12.1+dfsg-3-deb/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:trixie-slim
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
+
 LABEL    software="fastqc" \ 
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     base_image="debian:trixie-slim" \ 
     container="fastqc" \ 
     about.summary="quality control for high throughput sequence data" \ 

--- a/gatk/4.5.0.0/Dockerfile
+++ b/gatk/4.5.0.0/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bookworm-slim
 
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
-LABEL    software="gatk"
+LABEL    software="gatk" \
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>"
 
 ARG software_version=4.5.0.0
 

--- a/hmmer/3.4dfsg-2-deb/Dockerfile
+++ b/hmmer/3.4dfsg-2-deb/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:trixie-slim
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
+
 LABEL    software="hmmer" \ 
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     base_image="debian:trixie-slim" \ 
     container="hmmer" \ 
     about.summary="profile hidden Markov models for protein sequence analysis" \ 

--- a/interpro/5.69-101.0/Dockerfile
+++ b/interpro/5.69-101.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-LABEL authors="Laise Florentino (lcf@ebi.ac.uk), Matthias Blum (mblum@ebi.ac.uk)"
+LABEL maintainer="Laise Florentino (lcf@ebi.ac.uk), Matthias Blum (mblum@ebi.ac.uk)"
 
 ARG VERSION=5.69-101.0
 ENV TZ=Europe/London

--- a/metal/2011-03-25/Dockerfile
+++ b/metal/2011-03-25/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bullseye-slim
 
 
 LABEL    software="Metal" \ 
-    MAINTAINER="Sebastian Bassi <sebastian@toyoko.io>" \
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     base_image="debian:bullseye-slim" \ 
     about.summary="METAL is designed to facilitate meta-analysis of large datasets (such as several whole genome scans)" \ 
     about.home="https://csg.sph.umich.edu/abecasis/Metal/index.html" \ 

--- a/muscle/5.1.0-1-deb/Dockerfile
+++ b/muscle/5.1.0-1-deb/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:bookworm-slim
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
+
 LABEL    software="muscle" \ 
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     container="muscle" \ 
     about.summary="Multiple alignment program of protein sequences" \ 
     about.home="http://www.drive5.com/muscle/" \ 

--- a/ncbi-tools-bin/6.1.20170106-6-deb/Dockerfile
+++ b/ncbi-tools-bin/6.1.20170106-6-deb/Dockerfile
@@ -1,6 +1,7 @@
 FROM biocontainers/biocontainers:debian-buster-backports_cv2
-MAINTAINER biocontainers <biodocker@gmail.com>
+
 LABEL    software="ncbi-tools-bin" \ 
+    maintainer="Biocontainers <biodocker@gmail.com>" \
     base_image="biocontainers/biocontainers:debian-buster-backports_cv2" \ 
     container="ncbi-tools-bin" \ 
     about.summary="NCBI libraries for biology applications (text-based utilities)" \ 

--- a/openms/2.2.0/Dockerfile
+++ b/openms/2.2.0/Dockerfile
@@ -7,6 +7,7 @@ LABEL base_image="biocontainers:v1.0.0_cv4"
 LABEL version="6"
 LABEL software="OpenMS"
 LABEL software.version="2.2.0"
+LABEL maintainer="Hannes Rost <hannes.rost@utoronto.ca>"
 LABEL about.summary="C++ libraries ans tools for MS/MS data analysis"
 LABEL about.home="http://www.openms.org/"
 LABEL about.documentation="http://ftp.mi.fu-berlin.de/pub/OpenMS/release2.2.0-about.documentation/html/index.html"
@@ -14,9 +15,6 @@ LABEL about.license_file="https://github.com/OpenMS/OpenMS/blob/develop/LICENSE"
 LABEL about.license="SPDX:BSD-1-Clause"
 LABEL about.tags="Proteomics"
 LABEL extra.identifiers.biotools="openms"
-
-################## MAINTAINER ######################
-MAINTAINER Hannes Rost <hannes.rost@utoronto.ca>
 
 USER root
 

--- a/orthofinder/2.5.5/Dockerfile
+++ b/orthofinder/2.5.5/Dockerfile
@@ -8,6 +8,9 @@
 ################################################
 
 FROM python:3.10-slim-bullseye
+
+LABEL maintainer="Sebastian Bassi <sebastian@toyoko.io>"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -57,6 +60,3 @@ RUN orthofinder -f ${ORTHOFINDER_PATH}/ExampleData/
 ########################## clean source file #################################
 
 RUN rm /opt/${ORTHOFINDER_FILE_NAME}
-
-###############################################################
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>

--- a/phylip/1-3.697dfsg-1-deb/Dockerfile
+++ b/phylip/1-3.697dfsg-1-deb/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:bookworm-slim
-MAINTAINER biocontainers <sebastian@toyoko.io>
+
 LABEL    software="phylip" \ 
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     base_image="biocontainers/biocontainers:vdebian-buster-backports_cv1" \ 
     container="phylip" \ 
     about.summary="package of programs for inferring phylogenies" \ 

--- a/phylip/1-3.697dfsg-2-deb/Dockerfile
+++ b/phylip/1-3.697dfsg-2-deb/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:bookworm-slim
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
+
 LABEL    software="phylip" \ 
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     base_image="biocontainers/biocontainers:vdebian-buster-backports_cv1" \ 
     container="phylip" \ 
     about.summary="package of programs for inferring phylogenies" \ 

--- a/pilon/1.24-3-deb/Dockerfile
+++ b/pilon/1.24-3-deb/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:trixie-slim
 
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
 LABEL    software="pilon" \ 
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     base_image="debian:trixie-slim" \ 
     container="pilon" \ 
     about.summary="automated genome assembly improvement and variant detection tool" \ 

--- a/primer3/2.6.1-4-deb/Dockerfile
+++ b/primer3/2.6.1-4-deb/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bookworm
 
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
 LABEL    software="primer3" \ 
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     container="primer3" \ 
     about.summary="tool to design flanking oligo nucleotides for DNA amplification" \ 
     about.home="http://primer3.sourceforge.net" \ 

--- a/rsat/20240507/Dockerfile
+++ b/rsat/20240507/Dockerfile
@@ -19,10 +19,6 @@ LABEL about.license="AGPL-3.0-only"
 LABEL about.license_file="see also licenses at $RSAT/public_html/motif_databasess"
 LABEL maintainer="rsat-developers@list01.bio.ens.psl.eu"
 
-## <----- maintainers 
-
-MAINTAINER "rsat-developers@list01.bio.ens.psl.eu" 
-
 ##  <---- Prevent to open interactive dialogs during the installation process
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/spades/4.0.0/Dockerfile
+++ b/spades/4.0.0/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10.14-slim-bullseye
 
 LABEL    software="spades" \
-    author="Sebastian Bassi <sebastian@toyoko.io>" \
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     base_image="python:3.10.14-slim-bullseye" \
     container="spades" \
     about.summary="genome assembler for single-cell and isolates data sets" \

--- a/templates/debian/Dockerfile
+++ b/templates/debian/Dockerfile
@@ -20,7 +20,7 @@ LABEL    software="biopython" \
     about.copyright=" 2002-2009 Biopython contributors" \ 
     about.license="other" \ 
     about.license_file="/usr/share/doc/biopython/copyright" \
-    dockerfile.maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     about.tags=""
 
 USER root

--- a/trimmomatic/0.39dfsg-2-deb/Dockerfile
+++ b/trimmomatic/0.39dfsg-2-deb/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:trixie-slim
-MAINTAINER Sebastian Bassi <sebastian@toyoko.io>
+
 LABEL    software="trimmomatic" \ 
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
     base_image="debian:trixie-slim" \ 
     container="trimmomatic" \ 
     about.summary="flexible read trimming tool for Illumina NGS data" \ 


### PR DESCRIPTION
Updated maintainer field syntax:

Changes made:
- Replaced "MAINTAINER ..." metadata with "LABEL maintainer=..." because "MAINTAINER" is obsolete
- Replaced "dockerfile.author", "dockerfile.maintainer" and "LABEL author ..."with "LABEL maintainer=..." to maintain consistency as 
  "author" and "maintainer" are the same in this context.
  (Note: One file listed different authors and a separate maintainer. Author names were retained for credit, while maintainer 
  information was updated.)