### PR TITLE
antiSMASH 8.1 update

### DIFF
--- a/antismash/8.0.4/Dockerfile
+++ b/antismash/8.0.4/Dockerfile
@@ -3,9 +3,9 @@ LABEL    software="antismash" \
     base_image="debian:trixie-slim" \
     about.summary="the antibiotics and Secondary Metabolite Analysis SHell" \
     about.home="https://antismash.secondarymetabolites.org/#!/about" \
-    software.version="8.1" \
-    upstream.version="8.1" \
-    version="8.1" \
+    software.version="8.0.4" \
+    upstream.version="8.0.4" \
+    version="8.0.4" \
     about.copyright="" \
     about.license="GNU Affero General Public License version 3.0 or greater" \
     maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
@@ -14,6 +14,6 @@ USER root
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y apt-transport-https pip wget gnupg2 && wget http://dl.secondarymetabolites.org/antismash-stretch.list -O /etc/apt/sources.list.d/antismash.list && wget -q -O- http://dl.secondarymetabolites.org/antismash.asc | apt-key add - && apt update
 RUN apt install -y hmmer diamond-aligner fasttree prodigal ncbi-blast+ muscle5 glimmerhmm
-RUN wget https://github.com/antismash/antismash/archive/refs/tags/8-1.tar.gz && tar -zxf 8-1.tar.gz && rm 8-1.tar.gz
-RUN pip install ./antismash-8-1 --break-system-packages
+RUN wget https://github.com/antismash/antismash/archive/refs/tags/8-0-4.tar.gz && tar -zxf 8-0-4.tar.gz && rm 8-0-4.tar.gz
+RUN pip install ./antismash-8-0-4 --break-system-packages
 RUN mkdir -p /data/databases/ && ln -s /mnt/disks/bucket/data/databases/ /data/databases/

--- a/antismash/8.0.4/Dockerfile
+++ b/antismash/8.0.4/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:trixie-slim
+FROM python:3.11-slim-bookworm
 LABEL    software="antismash" \
-    base_image="debian:trixie-slim" \
+    base_image="python:3.11-slim-bookworm" \
     about.summary="the antibiotics and Secondary Metabolite Analysis SHell" \
     about.home="https://antismash.secondarymetabolites.org/#!/about" \
     software.version="8.0.4" \
@@ -12,8 +12,9 @@ LABEL    software="antismash" \
     about.tags=""
 USER root
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install -y apt-transport-https pip wget gnupg2 && wget http://dl.secondarymetabolites.org/antismash-stretch.list -O /etc/apt/sources.list.d/antismash.list && wget -q -O- http://dl.secondarymetabolites.org/antismash.asc | apt-key add - && apt update
-RUN apt install -y hmmer diamond-aligner fasttree prodigal ncbi-blast+ muscle5 glimmerhmm
+RUN apt update && apt install -y apt-transport-https pip wget gnupg2 && \
+    apt update
+RUN apt install -y hmmer2 diamond-aligner fasttree prodigal ncbi-blast+
 RUN wget https://github.com/antismash/antismash/archive/refs/tags/8-0-4.tar.gz && tar -zxf 8-0-4.tar.gz && rm 8-0-4.tar.gz
 RUN pip install ./antismash-8-0-4 --break-system-packages
 RUN mkdir -p /data/databases/ && ln -s /mnt/disks/bucket/data/databases/ /data/databases/

--- a/antismash/8.1/Dockerfile
+++ b/antismash/8.1/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:trixie-slim
+LABEL    software="antismash" \
+    base_image="debian:trixie-slim" \
+    about.summary="the antibiotics and Secondary Metabolite Analysis SHell" \
+    about.home="https://antismash.secondarymetabolites.org/#!/about" \
+    software.version="8.1" \
+    upstream.version="8.1" \
+    version="8.1" \
+    about.copyright="" \
+    about.license="GNU Affero General Public License version 3.0 or greater" \
+    maintainer="Sebastian Bassi <sebastian@toyoko.io>" \
+    about.tags=""
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install -y apt-transport-https pip wget gnupg2 && wget http://dl.secondarymetabolites.org/antismash-stretch.list -O /etc/apt/sources.list.d/antismash.list && wget -q -O- http://dl.secondarymetabolites.org/antismash.asc | apt-key add - && apt update
+RUN apt install -y hmmer diamond-aligner fasttree prodigal ncbi-blast+ muscle5 glimmerhmm
+RUN wget https://github.com/antismash/antismash/archive/refs/tags/8-1.tar.gz && tar -zxf 8-1.tar.gz && rm 8-1.tar.gz
+RUN pip install ./antismash-8-1 --break-system-packages
+RUN mkdir -p /data/databases/ && ln -s /mnt/disks/bucket/data/databases/ /data/databases/


### PR DESCRIPTION
Outdated:
- antiSMASH version is 7.1.0.1 but needs to be updated to current version 8.1
- update bookworm-slim to trixie-slim

Dependency
- hmm2 should be updated to HMMER version 3.4
- muscle should be updates to MUSCLE5 (v5)
- diamond-aligner should be updated to latest version 2.2.1