### PR TITLE
Add prokka 1.15.6 container, based on StaPH-B docker-builds

### DIFF
--- a/prokka/1.15.6/Dockerfile
+++ b/prokka/1.15.6/Dockerfile
@@ -1,0 +1,75 @@
+# Adapted from StaPH-B docker-builds:
+# https://github.com/StaPH-B/docker-builds/blob/master/build-files/prokka/1.15.6/Dockerfile
+
+ARG PROKKA_VER="1.15.6"
+ARG MINCED_VER="0.4.2"
+
+FROM ubuntu:noble AS app
+
+ARG PROKKA_VER
+ARG MINCED_VER
+
+LABEL base.image="ubuntu:noble"
+LABEL dockerfile.version="1"
+LABEL software="Prokka"
+LABEL software.version="${PROKKA_VER}"
+LABEL description="Automated prokaryotic genome annotation tool"
+LABEL website="https://github.com/tseemann/prokka"
+LABEL license="https://github.com/tseemann/prokka#licence"
+LABEL maintainer="Diya Nair"
+LABEL maintainer.email="diyasnair30@gmail.com"
+
+ARG DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    ca-certificates \
+    perl \
+    aragorn \
+    barrnap \
+    ncbi-blast+ \
+    hmmer \
+    infernal \
+    parallel \
+    bioperl \
+    libbio-searchio-hmmer-perl \
+    libxml-simple-perl \
+    prodigal \
+    ncbi-tools-bin \
+    default-jre-headless \
+    dpkg-dev \
+    gcc &&\
+    rm -rf /var/lib/apt/lists/* && apt-get autoclean
+# ncbi-tools-bin provides table2asn
+# dpkg-dev and gcc suppress a build warning
+
+# install minced
+RUN wget -q https://github.com/ctSkennerton/minced/releases/download/${MINCED_VER}/minced \
+    https://github.com/ctSkennerton/minced/releases/download/${MINCED_VER}/minced.jar &&\
+    chmod +x minced* &&\
+    mv minced* /usr/local/bin/
+
+# install prokka
+RUN wget -q https://github.com/tseemann/prokka/archive/refs/tags/v${PROKKA_VER}.tar.gz &&\
+    tar -xvf v${PROKKA_VER}.tar.gz && rm v${PROKKA_VER}.tar.gz
+
+ENV PATH=$PATH:/prokka-${PROKKA_VER}/bin \
+    LC_ALL=C
+
+# index database
+RUN prokka --setupdb
+
+CMD ["prokka", "--help"]
+
+WORKDIR /data
+
+## Test ##
+FROM app AS test
+ARG PROKKA_VER
+RUN prokka --listdb &&\
+    prokka --version &&\
+    blastp -help &&\
+    barrnap --help 2>&1 | grep Options &&\
+    prodigal -h &&\
+    tbl2asn --help
+RUN prokka /prokka-${PROKKA_VER}/test/genome.fna


### PR DESCRIPTION
Adds prokka 1.15.6 container, adapted from [StaPH-B docker-builds](https://github.com/StaPH-B/docker-builds/blob/master/build-files/prokka/1.15.6/Dockerfile) (cited in Dockerfile header)

Build succeeded (13/13 steps).

**Manual test** — ran full annotation against real genome data (not just import checks):
Result: `Annotation finished successfully.` Walltime 2.05 min. Predicted 6,048 CDS, 78 tRNAs, 12 rRNAs, 1 CRISPR array. All expected output files generated (`.gff`, `.gbk`, `.faa`, `.ffn`, `.tsv`, etc.), verified non-empty.