### PR TITLE
Add parsnp 2.1.5 container via bioconda

### DIFF
--- a/parsnp/2.1.5/Dockerfile
+++ b/parsnp/2.1.5/Dockerfile
@@ -1,0 +1,35 @@
+ARG PARSNP_VER="2.1.5"
+
+FROM condaforge/mambaforge:latest AS app
+
+ARG PARSNP_VER
+
+LABEL base.image="condaforge/mambaforge:latest"
+LABEL dockerfile.version="1"
+LABEL software="Parsnp"
+LABEL software.version="${PARSNP_VER}"
+LABEL description="Efficient microbial core genome alignment, SNP detection, and phylogeny for bacterial genomes"
+LABEL website="https://github.com/marbl/parsnp"
+LABEL license="https://github.com/marbl/parsnp/blob/master/LICENSE"
+LABEL maintainer="Diya Nair"
+LABEL maintainer.email="diyasnair30@gmail.com"
+
+# install via Bioconda (parsnp's own README recommends this over building from source,
+# which additionally requires a custom Muscle library build)
+RUN mamba install -y -c bioconda -c conda-forge "parsnp=${PARSNP_VER}" wget ca-certificates && \
+    mamba clean -afy
+
+CMD ["parsnp", "--help"]
+
+WORKDIR /data
+
+## Test ##
+FROM app AS test
+ARG PARSNP_VER
+RUN parsnp --version
+# pull down the real mers_virus example bundled in the parsnp repo and run an actual alignment
+RUN wget -q https://github.com/marbl/parsnp/archive/refs/tags/v${PARSNP_VER}.tar.gz &&\
+    tar -xzf v${PARSNP_VER}.tar.gz && rm v${PARSNP_VER}.tar.gz
+RUN parsnp -r parsnp-${PARSNP_VER}/examples/mers_virus/ref/England1.fna \
+    -d parsnp-${PARSNP_VER}/examples/mers_virus/genomes/*.fna \
+    -o /data/test-out --no-partition


### PR DESCRIPTION
Adds parsnp 2.1.5 container, installed via Bioconda 

**Build:**
docker build --platform linux/amd64 -t parsnp-test:2.1.5 parsnp/2.1.5/

Build succeeded (10/10 steps).

**Test** — build includes a test stage that runs the real alignment pipeline (not just import checks), using the mers_virus example dataset bundled in the parsnp repo:
parsnp -r examples/mers_virus/ref/England1.fna -d examples/mers_virus/genomes/*.fna -o test-out --no-partition

Completed successfully in ~3s as part of the build.

**Note on architecture:** Bioconda only publishes linux-64 (x86_64) and osx-64 builds for parsnp — no linux-aarch64 build exists. This container is built with --platform linux/amd64 and runs via emulation on Apple Silicon; there is no native arm64 image available. just wanted to flag the limitation as part of the PR. 